### PR TITLE
fix output format

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -18,8 +18,8 @@ function embedCode(filePath,originalPath) {
     var code = fs.readFileSync(filePath, "utf-8");
     var fileName = path.basename(filePath);
     var lang = getLang(filePath);
-    return `> [${fileName}](${originalPath})
-<a name="${fileName}"></a>
+    return `> <a name="${fileName}" href="${originalPath}">${fileName}</a>
+
 \`\`\` ${lang}
 ${code.trim()}
 \`\`\``

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -11,9 +11,11 @@ describe("parse", function () {
         assert(results.length > 0);
         var result = results[0];
         assert.equal(result.target, "[include](fixtures/test.js)");
-        assert.equal(result.replaced, '> [test.js](fixtures/test.js)\n' +
-            '<a name="test.js"></a>\n' +
-            '``` js\nconsole.log(\"test\");\n```');
+        var expected = '> <a name="test.js" href="fixtures/test.js">test.js</a>\n'
+            + '\n'
+            + '``` js\nconsole.log(\"test\");\n```';
+        console.log(expected);
+        assert.equal(result.replaced, expected);
     });
 });
 


### PR DESCRIPTION
close #3 

new format is

``````
> <a name="test.js" href="fixtures/test.js">test.js</a>

``` js
console.log("test");
```
``````
