### PR TITLE
Translate filename extensions to language names.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "engines": {
     "gitbook": "*"
   },
-  "dependencies": {},
+  "dependencies": {
+    "language-map": "^1.1.1"
+  },
   "devDependencies": {
     "babel": "^5.8.23",
     "espower-babel": "^3.3.0",

--- a/src/parser.js
+++ b/src/parser.js
@@ -2,6 +2,7 @@
 "use strict";
 var fs = require("fs");
 var path = require('path');
+var language_map = require('language-map');
 var re = /\[([^\]]*?)\]\(([^\)]*?)\)/gm;
 export function containIncludeLabel(label) {
     var reg = /^(include|import)$/;
@@ -31,9 +32,22 @@ export function getSliceRange(label) {
     return res ? res.slice(1) : [];
 }
 
+export function lookupLanguageByExtension(ext) {
+  for (var key in language_map) {
+    if (language_map.hasOwnProperty(key) && language_map[key].extensions) {
+      if(language_map[key].extensions.indexOf(ext) !== -1) {
+        return language_map[key].aceMode;
+      }
+    }
+  }
+
+  return undefined;
+}
+
 export function getLang(filePath) {
-    var suffix = path.extname(filePath);
-    return suffix.substring(1);
+    var ext = path.extname(filePath);
+
+    return lookupLanguageByExtension(ext) || ext;
 }
 export function embedCode(filePath, originalPath, start, end) {
     var code = fs.readFileSync(filePath, "utf-8");

--- a/test/fixtures/test.exs
+++ b/test/fixtures/test.exs
@@ -1,0 +1,1 @@
+IO.puts "test"

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -13,7 +13,20 @@ describe("parse", function () {
         assert.equal(result.target, "[include](fixtures/test.js)");
         var expected = '> <a name="test.js" href="fixtures/test.js">test.js</a>\n'
             + '\n'
-            + '``` js\nconsole.log(\"test\");\n```';
+            + '``` javascript\nconsole.log(\"test\");\n```';
+        assert.equal(result.replaced, expected);
+    });
+    it("should translate elixir extensions", function () {
+        var exs_content = `
+        [include](fixtures/test.exs)
+        `;
+        var results = parse(exs_content, __dirname);
+        assert(results.length > 0);
+        var result = results[0];
+        assert.equal(result.target, "[include](fixtures/test.exs)");
+        var expected = '> <a name="test.exs" href="fixtures/test.exs">test.exs</a>\n'
+            + '\n'
+            + '``` elixir\nIO.puts \"test\"\n```';
         assert.equal(result.replaced, expected);
     });
     context("sliced text", function () {
@@ -25,7 +38,7 @@ describe("parse", function () {
             assert.equal(result.target, multiLineContent);
             var expected = '> <a name="line.js" href="fixtures/line.js">line.js</a>\n'
                 + '\n'
-                + '``` js\n'
+                + '``` javascript\n'
                 + 'console.log(\"this is line 4\");\n'
                 + 'console.log(\"this is line 5\");\n'
                 + 'console.log(\"this is line 6\");\n'
@@ -40,7 +53,7 @@ describe("parse", function () {
             assert.equal(result.target, multiLineContent);
             var expected = '> <a name="line.js" href="fixtures/line.js">line.js</a>\n'
                 + '\n'
-                + '``` js\n'
+                + '``` javascript\n'
                 + 'console.log(\"this is line 9\");\n'
                 + 'console.log(\"this is line 10\");\n'
                 + '```';
@@ -54,7 +67,7 @@ describe("parse", function () {
             assert.equal(result.target, multiLineContent);
             var expected = '> <a name="line.js" href="fixtures/line.js">line.js</a>\n'
                 + '\n'
-                + '``` js\n'
+                + '``` javascript\n'
                 + 'console.log(\"this is line 1\");\n'
                 + 'console.log(\"this is line 2\");\n'
                 + '```';
@@ -76,4 +89,3 @@ describe("parse", function () {
         });
     })
 });
-


### PR DESCRIPTION
Some language's names don't exactly match their filename extensions.
One example is Elixir.  This change adds a translation function that
maps extensions to language names using an associative array.
Currently, the array only translate Elixir extensions.  Languages not
included in the array use the extension as the language name as they
did before this change.
