### PR TITLE
fix(parser): fix `lookupLanguageByExtension` error

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -33,15 +33,24 @@ export function getSliceRange(label) {
 }
 
 export function lookupLanguageByExtension(ext) {
-  for (var key in language_map) {
-    if (language_map.hasOwnProperty(key) && language_map[key].extensions) {
-      if(language_map[key].extensions.indexOf(ext) !== -1) {
-        return language_map[key].aceMode;
-      }
-    }
-  }
-
-  return undefined;
+    let aceMode;
+    Object.keys(language_map).some(langKey => {
+        const extensions = language_map[langKey]["extensions"];
+        /* TODO: These lang has not extensions
+        Ant Build System
+        Isabelle ROOT
+        Maven POMAnt Build System
+         */
+        if (!extensions) {
+            return false;
+        }
+        return extensions.some(extension => {
+            if (ext === extension) {
+                aceMode = language_map[langKey]["aceMode"];
+            }
+        });
+    });
+    return aceMode;
 }
 
 export function getLang(filePath) {
@@ -62,12 +71,18 @@ ${slicedCode.trim()}
 }
 
 function sliceCode(code, start, end) {
-  if (start === '' && end === '') return code;
+    if (start === '' && end === '') {
+        return code;
+    }
 
-  var splitted = code.split('\n');
-  if (start === '') { start = 1; }
-  if (end === '') { end = splitted.length; }
-  return splitted.slice(start - 1, end).join('\n');
+    var splitted = code.split('\n');
+    if (start === '') {
+        start = 1;
+    }
+    if (end === '') {
+        end = splitted.length;
+    }
+    return splitted.slice(start - 1, end).join('\n');
 }
 
 export function parse(content, baseDir) {

--- a/test/fixtures/test.rs
+++ b/test/fixtures/test.rs
@@ -1,0 +1,1 @@
+extern crate num;

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -29,6 +29,19 @@ describe("parse", function () {
             + '``` elixir\nIO.puts \"test\"\n```';
         assert.equal(result.replaced, expected);
     });
+    it("should translate Rust extensions", function () {
+        var exs_content = `
+        [include](fixtures/test.rs)
+        `;
+        var results = parse(exs_content, __dirname);
+        assert(results.length > 0);
+        var result = results[0];
+        assert.equal(result.target, "[include](fixtures/test.rs)");
+        var expected = '> <a name="test.rs" href="fixtures/test.rs">test.rs</a>\n'
+            + '\n'
+            + '``` rust\nextern crate num;\n```';
+        assert.equal(result.replaced, expected);
+    });
     context("sliced text", function () {
         it("should return sliced object for replace", function () {
             var multiLineContent = "[include:4-6, line.js](fixtures/line.js)";

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -1,51 +1,53 @@
 // LICENSE : MIT
 "use strict";
 import assert from "power-assert"
-import {parse,containIncludeLabel} from "../src/parser"
+import {parse, containIncludeLabel} from "../src/parser"
 var content = `
 [include](fixtures/test.js)
 `;
 describe("parse", function () {
-    it("should return object for replace", function () {
-        var results = parse(content, __dirname);
-        assert(results.length > 0);
-        var result = results[0];
-        assert.equal(result.target, "[include](fixtures/test.js)");
-        var expected = '> <a name="test.js" href="fixtures/test.js">test.js</a>\n'
-            + '\n'
-            + '``` javascript\nconsole.log(\"test\");\n```';
-        assert.equal(result.replaced, expected);
-    });
-    it("should translate elixir extensions", function () {
-        var exs_content = `
+    context("translate lang", function () {
+        it("should return object for replace", function () {
+            var results = parse(content, __dirname);
+            assert(results.length > 0);
+            var result = results[0];
+            assert.equal(result.target, "[include](fixtures/test.js)");
+            var expected = '> <a name="test.js" href="fixtures/test.js">test.js</a>\n'
+                + '\n'
+                + '``` javascript\nconsole.log(\"test\");\n```';
+            assert.equal(result.replaced, expected);
+        });
+        it("should translate elixir extensions", function () {
+            var exs_content = `
         [include](fixtures/test.exs)
         `;
-        var results = parse(exs_content, __dirname);
-        assert(results.length > 0);
-        var result = results[0];
-        assert.equal(result.target, "[include](fixtures/test.exs)");
-        var expected = '> <a name="test.exs" href="fixtures/test.exs">test.exs</a>\n'
-            + '\n'
-            + '``` elixir\nIO.puts \"test\"\n```';
-        assert.equal(result.replaced, expected);
-    });
-    it("should translate Rust extensions", function () {
-        var exs_content = `
+            var results = parse(exs_content, __dirname);
+            assert(results.length > 0);
+            var result = results[0];
+            assert.equal(result.target, "[include](fixtures/test.exs)");
+            var expected = '> <a name="test.exs" href="fixtures/test.exs">test.exs</a>\n'
+                + '\n'
+                + '``` elixir\nIO.puts \"test\"\n```';
+            assert.equal(result.replaced, expected);
+        });
+        it("should translate Rust extensions", function () {
+            var exs_content = `
         [include](fixtures/test.rs)
         `;
-        var results = parse(exs_content, __dirname);
-        assert(results.length > 0);
-        var result = results[0];
-        assert.equal(result.target, "[include](fixtures/test.rs)");
-        var expected = '> <a name="test.rs" href="fixtures/test.rs">test.rs</a>\n'
-            + '\n'
-            + '``` rust\nextern crate num;\n```';
-        assert.equal(result.replaced, expected);
+            var results = parse(exs_content, __dirname);
+            assert(results.length > 0);
+            var result = results[0];
+            assert.equal(result.target, "[include](fixtures/test.rs)");
+            var expected = '> <a name="test.rs" href="fixtures/test.rs">test.rs</a>\n'
+                + '\n'
+                + '``` rust\nextern crate num;\n```';
+            assert.equal(result.replaced, expected);
+        });
     });
     context("sliced text", function () {
         it("should return sliced object for replace", function () {
             var multiLineContent = "[include:4-6, line.js](fixtures/line.js)";
-            var results = parse(multiLineContent , __dirname);
+            var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, multiLineContent);
@@ -60,7 +62,7 @@ describe("parse", function () {
         });
         it("should return sliced `start`- text", function () {
             var multiLineContent = "[include:9-, line.js](fixtures/line.js)";
-            var results = parse(multiLineContent , __dirname);
+            var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, multiLineContent);
@@ -74,7 +76,7 @@ describe("parse", function () {
         });
         it("should return sliced -`end` text", function () {
             var multiLineContent = "[include:-2, line.js](fixtures/line.js)";
-            var results = parse(multiLineContent , __dirname);
+            var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, multiLineContent);


### PR DESCRIPTION
Some lang has not `extensions` and miss match lang.

e.g.) Treating Rust lang as Text is bad case.

close #8
