### PR TITLE
feat(parse): allow to use hardcode class

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ Result
     console.log("test");
     ```
 
+### Hardcoded class
+
+When you import a TypeScript file `.ts`:
+The parser correctly finds `.ts` in the [language-map](https://github.com/blakeembrey/language-map "language-map") extensions for both TypeScript and XML, then automatically chooses `XML`.
+
+If you want to specify language type, put `lang-<lang-name>` to label.
+
+```markdown
+[import, lang-typescript](hello-world.ts)
+```
+
+You can choose `<lang-name>` of `lang-<lang-name>` from language-map's `aceMode` value.
+
+- [blakeembrey/language-map: JSON version of the programming language map used in Linguist](https://github.com/blakeembrey/language-map "blakeembrey/language-map: JSON version of the programming language map used in Linguist")
+
+e.g.) typescript's aceMode value is `typescript`. 
+
+- https://github.com/blakeembrey/language-map/blob/b72edb8c2cb1b05d098782aa85dd2f573ed96ba3/languages.json#L4140
+
 ### Sliced Code
 
 If you want to slice imported code and show.

--- a/src/language-detection.js
+++ b/src/language-detection.js
@@ -1,0 +1,54 @@
+// LICENSE : MIT
+"use strict";
+const path = require('path');
+const language_map = require('language-map');
+export function lookupLanguageByAceMode(commands) {
+    let resultAceMode;
+    commands.forEach(command => {
+        const matchAceModes = /lang\-(.+)/g.exec(command);
+        if (matchAceModes == null) {
+            return
+        }
+        const matchLang = matchAceModes[1];
+        if (!matchLang) {
+            return;
+        }
+        Object.keys(language_map).some(langKey => {
+            const aceMode = language_map[langKey]["aceMode"];
+            if (matchLang === aceMode) {
+                resultAceMode = aceMode;
+            }
+        });
+    });
+    return resultAceMode;
+}
+
+export function lookupLanguageByExtension(ext) {
+    let aceMode;
+    Object.keys(language_map).some(langKey => {
+        const extensions = language_map[langKey]["extensions"];
+        /* TODO: These lang has not extensions
+         Ant Build System
+         Isabelle ROOT
+         Maven POMAnt Build System
+         */
+        if (!extensions) {
+            return false;
+        }
+        return extensions.some(extension => {
+            if (ext === extension) {
+                aceMode = language_map[langKey]["aceMode"];
+            }
+        });
+    });
+    return aceMode;
+}
+
+export function getLang(commands, filePath) {
+    const lang = lookupLanguageByAceMode(commands);
+    if (lang) {
+        return lang;
+    }
+    const ext = path.extname(filePath);
+    return lookupLanguageByExtension(ext) || ext;
+}

--- a/test/fixtures/test.ts
+++ b/test/fixtures/test.ts
@@ -1,0 +1,1 @@
+console.log("test");

--- a/test/language-detection-test.js
+++ b/test/language-detection-test.js
@@ -1,0 +1,41 @@
+// LICENSE : MIT
+"use strict";
+const assert = require("power-assert");
+const path = require("path");
+import {getLang, lookupLanguageByAceMode, lookupLanguageByExtension} from "../src/language-detection";
+describe("language-detection", function () {
+    describe("#lookupLanguageByAceMode", function () {
+        it("should resolve language type by acemode", function () {
+            const aceMode = lookupLanguageByAceMode(["lang-typescript"]);
+            assert.equal(aceMode, "typescript");
+        });
+    });
+    describe("#lookupLanguageByExtension", function () {
+        it("should resolve language type by acemode", function () {
+            const aceMode = lookupLanguageByExtension(".js");
+            assert.equal(aceMode, "javascript");
+        });
+    });
+    describe("#getLang", function () {
+        context("specified aceMode", function () {
+            it("should prefer use aceMode", function () {
+                const lang = getLang(["lang-typescript"], "/path/to/file.js");
+                assert.equal(lang, "typescript");
+            });
+            it("should detect using aceMode", function () {
+                const lang = getLang(["lang-typescript"], "/path/to/file.ts");
+                assert.equal(lang, "typescript");
+            });
+            it("should detect using aceMode, but fail, use ext as fallback", function () {
+                const lang = getLang([], "/path/to/file.ts");
+                assert.equal(lang, "xml");
+            });
+        });
+        context("other using ext", function () {
+            it("should detect using ext", function () {
+                const lang = getLang([], "/path/to/file.rs");
+                assert.equal(lang, "rust");
+            });
+        });
+    });
+});


### PR DESCRIPTION
Allow to use `lang-<lang>` to specify aceMode.

```
[include, lang-typescript](fixtures/test.ts)
```

Before: xml
After: typescript
- [x] Need Usage. Update README

fix #10
