### PR TITLE
fix(marker): fix unexpected marker usage

### DIFF
--- a/src/marker.js
+++ b/src/marker.js
@@ -24,7 +24,7 @@ const markerNameFormat = "(\\s*[a-zA-Z][\\w\\s]*)"; // Must contain a char.
  */
 export function getMarkerName(label) {
     // regex
-    const regstr = "\^(?:include|import):?" + markerNameFormat + "[,\\s]?.*\$"
+    const regstr = "\^(?:include|import):" + markerNameFormat + "[,\\s]?.*\$";
     const reg = new RegExp(regstr);
     const res = label.match(reg);
 

--- a/test/marker-test.js
+++ b/test/marker-test.js
@@ -69,6 +69,13 @@ describe("marker", function () {
                 const result = getMarkerName(command);
                 assert.equal(result, "my marker ");
             });
+            context("when : is luck", function () {
+                it("should return empty", function(){
+                    const command = "import my marker , test.cpp";
+                    const result = getMarkerName(command);
+                    assert.equal(result, "");
+                });
+            });
         });
     });
     describe("marker-slice", function () {


### PR DESCRIPTION
followup #12 snippet feature.

When the user write following

```
[import example.js](../../src/example.js)
```

Output in console:

```
markersSliceCode(): marker `  example.js` not found
```

This is unexpected behavior and breaking backward compatibility.

I think that `:` is alwawas required.

/cc @gdolle
