### PR TITLE
Title feature #19 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,37 @@ or
 ```markdown
 [import](fixtures/test.js)
 ```
+Result
+
+    ``` js
+    console.log("test");
+    ```
+
+### Title
+
+A title can be added using `title` or `title:<the title>`. In the first case,
+the filename will be displayed.
+
+```
+[include,title](fixtures/test.js)
+```
 
 Result
 
     > <a name="test.js" href="fixtures/test.js">test.js</a>
-    
+
+    ``` js
+    console.log("test");
+    ```
+
+```
+[include,title:"Example of title"](fixtures/test.js)
+```
+
+Result
+
+    > <a name="test.js" href="fixtures/test.js">Example of title</a>
+
     ``` js
     console.log("test");
     ```

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "gitbook": "*"
   },
   "dependencies": {
-    "language-map": "^1.1.1"
+    "language-map": "^1.1.1",
+    "handlebars":"^4.0.5"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",

--- a/src/marker.js
+++ b/src/marker.js
@@ -22,13 +22,8 @@ const markerNameFormat = "(\\s*[a-zA-Z][\\w\\s]*)"; // Must contain a char.
 /*
  * format: [import:<markername>](path/to/file)
  */
-export function getMarkerName(label) {
-    // regex
-    const regstr = "\^(?:include|import):" + markerNameFormat + "[,\\s]?.*\$";
-    const reg = new RegExp(regstr);
-    const res = label.match(reg);
-
-    return res ? res[1] : '';
+export function getMarker(keyValObject) {
+    return keyValObject.marker;
 }
 
 
@@ -37,12 +32,11 @@ export function getMarkerName(label) {
  * check if the import filled has a markername.
  * @example:
  *      hasMarker(label)
- * @param {string} label
  * @returns {boolean}
  */
-export function hasMarker(label) {
-    const marker = getMarkerName(label);
-    return (marker !== '');
+export function hasMarker(keyValObject) {
+    const marker = getMarker(keyValObject);
+    return (marker !== undefined);
 }
 
 /* Parse the code from given markers
@@ -55,7 +49,7 @@ export function hasMarker(label) {
  * @param {string} markername
  * @returns {string}
  */
-export function markersSliceCode(code, markername) {
+export function markerSliceCode(code, markername) {
     if (markername === undefined) {
         return code;
     }

--- a/src/marker.js
+++ b/src/marker.js
@@ -71,12 +71,20 @@ export function markerSliceCode(code, markername) {
 }
 
 
-// Replace all regex occurence by sub in the string str,
+/** Replace all regex occurence by sub in the string str,
+ * @param {string} str
+ * @param {string} reg
+ * @param {string} sub
+ * @return {string}
+ */
 export function replaceAll(str, reg, sub) {
     return str.replace(new RegExp(reg, 'g'), sub);
 }
 
-// Function that remove all markers in the given code
+/** Function that remove all markers in the given code
+ * @param {string} code
+ * @return {string}
+ */
 export function removeMarkers(code) {
     // various language comment
     const balise = "\\[" + markerNameFormat + "\\]";

--- a/src/marker.js
+++ b/src/marker.js
@@ -21,6 +21,8 @@ const markerNameFormat = "(\\s*[a-zA-Z][\\w\\s]*)"; // Must contain a char.
 
 /*
  * format: [import:<markername>](path/to/file)
+ * @param {Object} keyValObject
+ * @return {string}
  */
 export function getMarker(keyValObject) {
     return keyValObject.marker;
@@ -32,6 +34,7 @@ export function getMarker(keyValObject) {
  * check if the import filled has a markername.
  * @example:
  *      hasMarker(label)
+ * @param {Object} keyValObject
  * @returns {boolean}
  */
 export function hasMarker(keyValObject) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -122,14 +122,14 @@ export function generateEmbedCode(keyValueObject, lang, fileName, originalPath, 
 > .link:{{originalPath}}[Code {{count}}: {{title}}]
 anchor:{{id}}[Code {{count}}]
         {% else %}
-> <a id="{{id}}" href="{{originalPath}}">{{title}}</a>
+> <a id="{{id}}" href="{{originalPath}}">Code {{count}}: {{title}}</a>
         {% endif %}
     {{else}}
         {% if file.type=="asciidoc" %}
 > .link:{{originalPath}}[Code {{count}}: {{title}}]
 anchor:{{title}}[Code {{count}}]
         {% else %}
-> <a id="{{title}}" href="{{originalPath}}">{{title}}</a>
+> <a id="{{title}}" href="{{originalPath}}">Code {{count}}: {{title}}</a>
         {% endif %}
     {{/if}}
 {{else}}

--- a/src/parser.js
+++ b/src/parser.js
@@ -7,8 +7,17 @@ const Handlebars = require("handlebars")
 import {getLang} from "./language-detection";
 import {getMarker, hasMarker, markerSliceCode, removeMarkers} from "./marker";
 import {sliceCode, hasSliceRange, getSliceRange} from "./slicer";
-import {parseTitle} from "./title"
+import {hasTitle,parseTitle} from "./title"
 const markdownLinkFormatRegExp = /\[([^\]]*?)\]\(([^\)]*?)\)/gm;
+
+/**
+ * A counter to count how many code are imported.
+ */
+var codeCounter = (function() {
+    var count = 0;
+        return function() { return count++; };  // Return and increment
+})();
+
 /**
  * split label to commands
  * @param {string} label
@@ -90,17 +99,28 @@ export function embedCode({lang, filePath, originalPath, label}) {
 }
 
 export function generateEmbedCode(keyValueObject, lang, fileName, originalPath, content) {
+    const count = hasTitle(keyValueObject) ? codeCounter():-1;
     // merge objects
     // if keyValueObject has `lang` key, that is overwrited by `lang` of right.
-    const context = Object.assign({}, keyValueObject, { lang, fileName, originalPath, content });
+    const context = Object.assign({}, keyValueObject, { lang, fileName, originalPath, content, count });
 
     // if has the title, add anchor link
     const source =`\
 {{#if title}}
     {{#if id}}
+        {% if file.type=="asciidoc" %}
+> .link:{{originalPath}}[Code {{count}}: {{title}}]
+anchor:{{id}}[Code {{count}}]
+        {% else %}
 > <a id="{{id}}" href="{{originalPath}}">{{title}}</a>
+        {% endif %}
     {{else}}
+        {% if file.type=="asciidoc" %}
+> .link:{{originalPath}}[Code {{count}}: {{title}}]
+anchor:{{title}}[Code {{count}}]
+        {% else %}
 > <a id="{{title}}" href="{{originalPath}}">{{title}}</a>
+        {% endif %}
     {{/if}}
 {{else}}
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -50,6 +50,7 @@ export function containIncludeCommand(commands = []) {
  * @example
  *      [import,title:"<thetitle>",label:"<thelabel>"](path/to/file.ext)
  * @param {string} label
+ * @return {Array}
  */
 export function parseVariablesFromLabel(label) {
     var keyvals = {
@@ -75,10 +76,10 @@ export function parseVariablesFromLabel(label) {
 /**
  * generate code with options
  * @param {string} lang
- * @param {bool,string} title
  * @param {string} filePath
  * @param {string} originalPath
  * @param {string} label
+ * @return {string}
  */
 export function embedCode({lang, filePath, originalPath, label}) {
     const code = fs.readFileSync(filePath, "utf-8");
@@ -98,6 +99,15 @@ export function embedCode({lang, filePath, originalPath, label}) {
     return generateEmbedCode(keyValueObject, lang, fileName, originalPath, content);
 }
 
+/**
+ * generate code from options
+ * @param keyValueObject
+ * @param {string} lang
+ * @param {string} fileName
+ * @param {string} originalPath
+ * @param {string} content
+ * @return {string}
+ */
 export function generateEmbedCode(keyValueObject, lang, fileName, originalPath, content) {
     const count = hasTitle(keyValueObject) ? codeCounter():-1;
     // merge objects
@@ -137,6 +147,12 @@ anchor:{{title}}[Code {{count}}]
     return output;
 };
 
+/**
+ * generate code with options
+ * @param {string} content
+ * @param {string} baseDir
+ * @return {string}
+ */
 export function parse(content, baseDir) {
     const results = [];
     let res;

--- a/src/parser.js
+++ b/src/parser.js
@@ -58,9 +58,9 @@ export function parseVariablesFromLabel(label) {
         "id":undefined,
         "marker":undefined
     };
-    for(var key in keyvals) {
+    Object.keys(keyvals).forEach(key => {
         var keyReg=key;
-        if(key=="marker") {
+        if(key==="marker") {
             keyReg="import|include";
         }
         const regStr = "\^.*,?\\s*("+keyReg+")\\s*:\\s*[\"']([^'\"]*)[\"'],?.*\$";
@@ -69,7 +69,7 @@ export function parseVariablesFromLabel(label) {
         if(res) {
             keyvals[key]=res[2];
         }
-    }
+    });
     return keyvals;
 }
 
@@ -101,7 +101,7 @@ export function embedCode({lang, filePath, originalPath, label}) {
 
 /**
  * generate code from options
- * @param keyValueObject
+ * @param {Object} keyValueObject
  * @param {string} lang
  * @param {string} fileName
  * @param {string} originalPath
@@ -114,7 +114,8 @@ export function generateEmbedCode(keyValueObject, lang, fileName, originalPath, 
     // if keyValueObject has `lang` key, that is overwrited by `lang` of right.
     const context = Object.assign({}, keyValueObject, { lang, fileName, originalPath, content, count });
 
-    // if has the title, add anchor link
+    // if has the title, display the title with an anchor link.
+    // Mix of handlerbars and markdown templates to handle file types.
     const source =`\
 {{#if title}}
     {{#if id}}
@@ -143,7 +144,6 @@ anchor:{{title}}[Code {{count}}]
     const template = Handlebars.compile(source);
     // compile with data
     const output = template(context);
-    // => markdown strings
     return output;
 };
 

--- a/src/title.js
+++ b/src/title.js
@@ -5,18 +5,20 @@
  *      [import,title:<the title>](path/to/file)
  */
 
-/*
- * format: [import,title:<the title>](path/to/file)
- * Get the specified <the title>
+/* Get the specified <the title>
  * @example:
  *     getTitle(keyValObject)
- *
+ * @param keyValObject
  * @return {boolean,string}
  */
 export function getTitle(keyValObject) {
     return keyValObject.title;
 }
 
+/* Check if a title is specified in the option
+ * @param keyValObject
+ * @return {boolean}
+ */
 export function hasTitle(keyValObject) {
     const title = getTitle(keyValObject);
     return (title !== undefined);

--- a/src/title.js
+++ b/src/title.js
@@ -17,3 +17,7 @@ export function getTitle(keyValObject) {
     return keyValObject.title;
 }
 
+export function hasTitle(keyValObject) {
+    const title = getTitle(keyValObject);
+    return (title !== undefined);
+}

--- a/src/title.js
+++ b/src/title.js
@@ -1,0 +1,43 @@
+// LICENSE : MIT
+/*
+ * Gibook usage:
+ *
+ *      [import,title](path/to/file)
+ *      [import,title:<the title>](path/to/file)
+ */
+
+const spaces = "[ \t]*"; // h spaces
+const titleFormat = "([^'\"]*)?";
+
+/*
+ * format: [import,title:<the title>](path/to/file)
+ * Get the specified <the title>
+ * @example:
+ *     parseTitle(label,fileName)
+ * @param {string} label
+ * @param {string} fileName
+ *
+ * @return {boolean,string}
+ */
+export function parseTitle(label, fileName) {
+    let title=[false, undefined];
+    const regstr2 = "\^.*,?" + spaces + "title"+ spaces
+        + ":"+ spaces +"[\"']" + titleFormat + "[\"']" + spaces
+        + ",?.*\$";
+    const reg2 = new RegExp(regstr2);
+    const res2 = label.match(reg2);
+
+    if( res2 ) {
+        title=[true, res2[1]];
+    }
+    else {
+        const regstr1 = "\^.*,?" + spaces + "title"+ spaces + ",?.*\$";
+        const reg1 = new RegExp(regstr1);
+        const res1 = label.match(reg1);
+        if( res1 ) {
+            title=[true, fileName];
+        }
+    }
+    return title;
+}
+

--- a/src/title.js
+++ b/src/title.js
@@ -2,42 +2,18 @@
 /*
  * Gibook usage:
  *
- *      [import,title](path/to/file)
  *      [import,title:<the title>](path/to/file)
  */
-
-const spaces = "[ \t]*"; // h spaces
-const titleFormat = "([^'\"]*)?";
 
 /*
  * format: [import,title:<the title>](path/to/file)
  * Get the specified <the title>
  * @example:
- *     parseTitle(label,fileName)
- * @param {string} label
- * @param {string} fileName
+ *     getTitle(keyValObject)
  *
  * @return {boolean,string}
  */
-export function parseTitle(label, fileName) {
-    let title=[false, undefined];
-    const regstr2 = "\^.*,?" + spaces + "title"+ spaces
-        + ":"+ spaces +"[\"']" + titleFormat + "[\"']" + spaces
-        + ",?.*\$";
-    const reg2 = new RegExp(regstr2);
-    const res2 = label.match(reg2);
-
-    if( res2 ) {
-        title=[true, res2[1]];
-    }
-    else {
-        const regstr1 = "\^.*,?" + spaces + "title"+ spaces + ",?.*\$";
-        const reg1 = new RegExp(regstr1);
-        const res1 = label.match(reg1);
-        if( res1 ) {
-            title=[true, fileName];
-        }
-    }
-    return title;
+export function getTitle(keyValObject) {
+    return keyValObject.title;
 }
 

--- a/src/title.js
+++ b/src/title.js
@@ -8,15 +8,15 @@
 /* Get the specified <the title>
  * @example:
  *     getTitle(keyValObject)
- * @param keyValObject
- * @return {boolean,string}
+ * @param {Object} keyValObject
+ * @return {string}
  */
 export function getTitle(keyValObject) {
     return keyValObject.title;
 }
 
 /* Check if a title is specified in the option
- * @param keyValObject
+ * @param {Object} keyValObject
  * @return {boolean}
  */
 export function hasTitle(keyValObject) {

--- a/test/marker-test.js
+++ b/test/marker-test.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("power-assert");
-import {getMarkerName, hasMarker, markersSliceCode, removeMarkers} from "../src/marker";
+import {getMarkerName, hasMarker, markerSliceCode, removeMarkers} from "../src/marker";
 
 //-------------------------------------------------------------------------------
 // Test C++ Code
@@ -62,85 +62,85 @@ const expectedMarker6 = `    int h;`;
 
 
 describe("marker", function () {
-    describe("#hasMarker", function () {
-        context("when have not marker", function () {
-            it("should return false", function () {
-                assert(!hasMarker("import:1-2, test.cpp"));
-                assert(!hasMarker("import test.cpp"));
-                assert(!hasMarker("import, test.cpp"));
-                assert(!hasMarker("import, lang-typescript"));
-            });
-        });
-        context("when have marker", function () {
-            it("should return true", function () {
-                assert(hasMarker("import:mark, test.cpp"));
-                assert(hasMarker("import:mark ,test.cpp"));
-                assert(hasMarker("import:mark2"));
-            });
-        });
-    });
-    describe("marker-label", function () {
-        describe("#getMarkerName", function () {
-            it("should return", function () {
-                const command = "import:my marker , test.cpp";
-                const result = getMarkerName(command);
-                assert.equal(result, "my marker ");
-            });
-            context("when use the slice code", function () {
-                it("should marker is empty", function () {
-                    const command = "import:1-10, test.cpp";
-                    const result = getMarkerName(command);
-                    assert.equal(result, "");
-                });
-            });
-            context("when : is luck", function () {
-                it("should return empty", function () {
-                    const command = "import my marker , test.cpp";
-                    const result = getMarkerName(command);
-                    assert.equal(result, "");
-                });
-            });
-        });
-    });
+//    describe("#hasMarker", function () {
+//        context("when have not marker", function () {
+//            it("should return false", function () {
+//                assert(!hasMarker("import:1-2, test.cpp"));
+//                assert(!hasMarker("import test.cpp"));
+//                assert(!hasMarker("import, test.cpp"));
+//                assert(!hasMarker("import, lang-typescript"));
+//            });
+//        });
+//        context("when have marker", function () {
+//            it("should return true", function () {
+//                assert(hasMarker("import:mark, test.cpp"));
+//                assert(hasMarker("import:mark ,test.cpp"));
+//                assert(hasMarker("import:mark2"));
+//            });
+//        });
+//    });
+//    describe("marker-label", function () {
+//        describe("#getMarkerName", function () {
+//            it("should return", function () {
+//                const command = "import:my marker , test.cpp";
+//                const result = getMarkerName(command);
+//                assert.equal(result, "my marker ");
+//            });
+//            context("when use the slice code", function () {
+//                it("should marker is empty", function () {
+//                    const command = "import:1-10, test.cpp";
+//                    const result = getMarkerName(command);
+//                    assert.equal(result, "");
+//                });
+//            });
+//            context("when : is luck", function () {
+//                it("should return empty", function () {
+//                    const command = "import my marker , test.cpp";
+//                    const result = getMarkerName(command);
+//                    assert.equal(result, "");
+//                });
+//            });
+//        });
+//    });
     describe("marker-slice", function () {
         context("#nested", function () {
             it("should slice code between [marker0] keeping inner markers", function () {
                 const markerName = "marker0";
-                const result = markersSliceCode(cppcode, markerName);
+                const result = markerSliceCode(cppcode, markerName);
                 assert.equal(result, expectedMarker0);
             });
         });
         context("#comment-style", function () {
             it("should slice code between [marker1] with comment //:", function () {
                 const markerName = "marker1";
-                const result = markersSliceCode(cppcode, markerName);
+                const result = markerSliceCode(cppcode, markerName);
                 assert.equal(result, expectedMarker1);
             });
             it("should slice code between [marker2] using comment /**", function () {
                 const markerName = "marker2";
-                const result = markersSliceCode(cppcode, markerName);
+                const result = markerSliceCode(cppcode, markerName);
                 assert.equal(result, expectedMarker2);
             });
             it("should slice code between [marker3] using comment ///", function () {
                 const markerName = "marker3";
-                const result = markersSliceCode(cppcode, markerName);
+                const result = markerSliceCode(cppcode, markerName);
                 assert.equal(result, expectedMarker3);
             });
         });
         context("#comment-style", function () {
             it("should slice code between [marker 4]", function () {
                 const markerName = "marker 4";
-                const result = markersSliceCode(cppcode, markerName);
+                const result = markerSliceCode(cppcode, markerName);
                 assert.equal(result, expectedMarker4);
             });
             it("should slice code between [marker5 space]", function () {
                 const markerName = "marker5 space";
-                const result = markersSliceCode(cppcode, markerName);
+                const result = markerSliceCode(cppcode, markerName);
                 assert.equal(result, expectedMarker5);
             });
             it("should slice code between [ marker 6 ]", function () {
                 const markerName = " marker 6 ";
-                const result = markersSliceCode(cppcode, markerName);
+                const result = markerSliceCode(cppcode, markerName);
                 assert.equal(result, expectedMarker6);
             });
         });
@@ -149,7 +149,7 @@ describe("marker", function () {
         context("#getMarkerName", function () {
             it("should slice code between [marker0] and remove markers [marker1]", function () {
                 const markerName = "marker0";
-                const result = removeMarkers(markersSliceCode(cppcode, markerName));
+                const result = removeMarkers(markerSliceCode(cppcode, markerName));
                 assert.equal(result, expectedMarker01);
             });
         });

--- a/test/marker-test.js
+++ b/test/marker-test.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("power-assert");
-import {getMarkerName, hasMarker, markerSliceCode, removeMarkers} from "../src/marker";
+import {getMarker, hasMarker, markerSliceCode, removeMarkers} from "../src/marker";
 
 //-------------------------------------------------------------------------------
 // Test C++ Code
@@ -62,46 +62,27 @@ const expectedMarker6 = `    int h;`;
 
 
 describe("marker", function () {
-//    describe("#hasMarker", function () {
-//        context("when have not marker", function () {
-//            it("should return false", function () {
-//                assert(!hasMarker("import:1-2, test.cpp"));
-//                assert(!hasMarker("import test.cpp"));
-//                assert(!hasMarker("import, test.cpp"));
-//                assert(!hasMarker("import, lang-typescript"));
-//            });
-//        });
-//        context("when have marker", function () {
-//            it("should return true", function () {
-//                assert(hasMarker("import:mark, test.cpp"));
-//                assert(hasMarker("import:mark ,test.cpp"));
-//                assert(hasMarker("import:mark2"));
-//            });
-//        });
-//    });
-//    describe("marker-label", function () {
-//        describe("#getMarkerName", function () {
-//            it("should return", function () {
-//                const command = "import:my marker , test.cpp";
-//                const result = getMarkerName(command);
-//                assert.equal(result, "my marker ");
-//            });
-//            context("when use the slice code", function () {
-//                it("should marker is empty", function () {
-//                    const command = "import:1-10, test.cpp";
-//                    const result = getMarkerName(command);
-//                    assert.equal(result, "");
-//                });
-//            });
-//            context("when : is luck", function () {
-//                it("should return empty", function () {
-//                    const command = "import my marker , test.cpp";
-//                    const result = getMarkerName(command);
-//                    assert.equal(result, "");
-//                });
-//            });
-//        });
-//    });
+    describe("#hasMarker", function () {
+        context("when have not marker", function () {
+            it("should return false", function () {
+                assert(!hasMarker(new Object({title:undefined,id:undefined,marker:undefined})));
+            });
+        });
+        context("when have marker", function () {
+            it("should return true", function () {
+                assert(hasMarker(new Object({title:undefined,id:undefined,marker:'test'})));
+            });
+        });
+    });
+    describe("marker-label", function () {
+        describe("#getMarkerName", function () {
+            it("should return", function () {
+                const command = "import:my marker , test.cpp";
+                const result = getMarker(new Object({title:undefined,id:undefined,marker:"my marker"}));
+                assert.equal(result, "my marker");
+            });
+        });
+    });
     describe("marker-slice", function () {
         context("#nested", function () {
             it("should slice code between [marker0] keeping inner markers", function () {

--- a/test/marker-test.js
+++ b/test/marker-test.js
@@ -65,12 +65,12 @@ describe("marker", function () {
     describe("#hasMarker", function () {
         context("when have not marker", function () {
             it("should return false", function () {
-                assert(!hasMarker(new Object({title:undefined,id:undefined,marker:undefined})));
+                assert(!hasMarker({title:undefined,id:undefined,marker:undefined}));
             });
         });
         context("when have marker", function () {
             it("should return true", function () {
-                assert(hasMarker(new Object({title:undefined,id:undefined,marker:'test'})));
+                assert(hasMarker({title:undefined,id:undefined,marker:'test'}));
             });
         });
     });
@@ -78,7 +78,7 @@ describe("marker", function () {
         describe("#getMarkerName", function () {
             it("should return", function () {
                 const command = "import:my marker , test.cpp";
-                const result = getMarker(new Object({title:undefined,id:undefined,marker:"my marker"}));
+                const result = getMarker({title:undefined,id:undefined,marker:"my marker"});
                 assert.equal(result, "my marker");
             });
         });

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -12,9 +12,18 @@ describe("parse", function () {
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, "[include,title:\"test.js\"](fixtures/test.js)");
-            var expected = '> <a id="test.js" href="fixtures/test.js">test.js</a>\n'
+//------------------------------------------------------------------------------
+            var expected =`\
+        {% if file.type=="asciidoc" %}
+> .link:fixtures/test.js[Code 0: test.js]
+anchor:test.js[Code 0]
+        {% else %}
+> <a id="test.js" href="fixtures/test.js">test.js</a>
+        {% endif %}
+`
                 + '\n'
                 + '``` javascript\nconsole.log(\"test\");\n```';
+//------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
         it("should prefer use lang-<aceMode>", function () {
@@ -23,9 +32,18 @@ describe("parse", function () {
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, "[include, title:\"test.ts\", lang-typescript](fixtures/test.ts)");
-            var expected = '> <a id="test.ts" href="fixtures/test.ts">test.ts</a>\n'
+//------------------------------------------------------------------------------
+            var expected =`\
+        {% if file.type=="asciidoc" %}
+> .link:fixtures/test.ts[Code 1: test.ts]
+anchor:test.ts[Code 1]
+        {% else %}
+> <a id="test.ts" href="fixtures/test.ts">test.ts</a>
+        {% endif %}
+`
                 + '\n'
                 + '``` typescript\nconsole.log(\"test\");\n```';
+//------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
         it("should translate elixir extensions", function () {
@@ -34,9 +52,18 @@ describe("parse", function () {
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, "[include, title:\"test.exs\"](fixtures/test.exs)");
-            var expected = '> <a id="test.exs" href="fixtures/test.exs">test.exs</a>\n'
+//------------------------------------------------------------------------------
+            var expected =`\
+        {% if file.type=="asciidoc" %}
+> .link:fixtures/test.exs[Code 2: test.exs]
+anchor:test.exs[Code 2]
+        {% else %}
+> <a id="test.exs" href="fixtures/test.exs">test.exs</a>
+        {% endif %}
+`
                 + '\n'
                 + '``` elixir\nIO.puts \"test\"\n```';
+//------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
         it("should translate Rust extensions", function () {
@@ -45,9 +72,18 @@ describe("parse", function () {
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, "[include, title:\"test.rs\"](fixtures/test.rs)");
-            var expected = '> <a id="test.rs" href="fixtures/test.rs">test.rs</a>\n'
+//------------------------------------------------------------------------------
+            var expected =`\
+        {% if file.type=="asciidoc" %}
+> .link:fixtures/test.rs[Code 3: test.rs]
+anchor:test.rs[Code 3]
+        {% else %}
+> <a id="test.rs" href="fixtures/test.rs">test.rs</a>
+        {% endif %}
+`
                 + '\n'
                 + '``` rust\nextern crate num;\n```';
+//------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
     });
@@ -58,13 +94,22 @@ describe("parse", function () {
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, multiLineContent);
-            var expected = '> <a id="line.js" href="fixtures/line.js">line.js</a>\n'
+//------------------------------------------------------------------------------
+            var expected =`\
+        {% if file.type=="asciidoc" %}
+> .link:fixtures/line.js[Code 4: line.js]
+anchor:line.js[Code 4]
+        {% else %}
+> <a id="line.js" href="fixtures/line.js">line.js</a>
+        {% endif %}
+`
                 + '\n'
                 + '``` javascript\n'
                 + 'console.log(\"this is line 4\");\n'
                 + 'console.log(\"this is line 5\");\n'
                 + 'console.log(\"this is line 6\");\n'
                 + '```';
+//------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
         it("should return sliced `start`- text", function () {
@@ -73,12 +118,21 @@ describe("parse", function () {
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, multiLineContent);
-            var expected = '> <a id="line.js" href="fixtures/line.js">line.js</a>\n'
+//------------------------------------------------------------------------------
+            var expected =`\
+        {% if file.type=="asciidoc" %}
+> .link:fixtures/line.js[Code 5: line.js]
+anchor:line.js[Code 5]
+        {% else %}
+> <a id="line.js" href="fixtures/line.js">line.js</a>
+        {% endif %}
+`
                 + '\n'
                 + '``` javascript\n'
                 + 'console.log(\"this is line 9\");\n'
                 + 'console.log(\"this is line 10\");\n'
                 + '```';
+//------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
         it("should return sliced -`end` text", function () {
@@ -87,12 +141,21 @@ describe("parse", function () {
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, multiLineContent);
-            var expected = '> <a id="line.js" href="fixtures/line.js">line.js</a>\n'
+//------------------------------------------------------------------------------
+            var expected =`\
+        {% if file.type=="asciidoc" %}
+> .link:fixtures/line.js[Code 6: line.js]
+anchor:line.js[Code 6]
+        {% else %}
+> <a id="line.js" href="fixtures/line.js">line.js</a>
+        {% endif %}
+`
                 + '\n'
                 + '``` javascript\n'
                 + 'console.log(\"this is line 1\");\n'
                 + 'console.log(\"this is line 2\");\n'
                 + '```';
+//------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
     });
@@ -106,11 +169,20 @@ describe("parse", function () {
             assert(results.length > 0);
             const result = results[0];
             assert.equal(result.target, multiLineContent);
-            const expected = '> <a id="marker.cpp" href="fixtures/marker.cpp">marker.cpp</a>\n'
+//------------------------------------------------------------------------------
+            var expected =`\
+        {% if file.type=="asciidoc" %}
+> .link:fixtures/marker.cpp[Code 7: marker.cpp]
+anchor:marker.cpp[Code 7]
+        {% else %}
+> <a id="marker.cpp" href="fixtures/marker.cpp">marker.cpp</a>
+        {% endif %}
+`
                 + '\n'
                 + '``` c_cpp\n'
                 + expectedMarker01 + "\n"
                 + '```';
+//------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
     });
@@ -163,9 +235,19 @@ describe("parse", function () {
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, "[include, title:'This is a title'](fixtures/test.js)");
-            var expected = '> <a id="This is a title" href="fixtures/test.js">This is a title</a>\n'
-                + '\n'
-                + '``` javascript\nconsole.log("test");\n```';
+//------------------------------------------------------------------------------
+            var expected =`\
+        {% if file.type=="asciidoc" %}
+> .link:fixtures/test.js[Code 8: This is a title]
+anchor:This is a title[Code 8]
+        {% else %}
+> <a id="This is a title" href="fixtures/test.js">This is a title</a>
+        {% endif %}
+
+\`\`\` javascript
+console.log("test");
+\`\`\``;
+//------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
     });

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -18,7 +18,7 @@ describe("parse", function () {
 > .link:fixtures/test.js[Code 0: test.js]
 anchor:test.js[Code 0]
         {% else %}
-> <a id="test.js" href="fixtures/test.js">test.js</a>
+> <a id="test.js" href="fixtures/test.js">Code 0: test.js</a>
         {% endif %}
 `
                 + '\n'
@@ -38,7 +38,7 @@ anchor:test.js[Code 0]
 > .link:fixtures/test.ts[Code 1: test.ts]
 anchor:test.ts[Code 1]
         {% else %}
-> <a id="test.ts" href="fixtures/test.ts">test.ts</a>
+> <a id="test.ts" href="fixtures/test.ts">Code 1: test.ts</a>
         {% endif %}
 `
                 + '\n'
@@ -58,7 +58,7 @@ anchor:test.ts[Code 1]
 > .link:fixtures/test.exs[Code 2: test.exs]
 anchor:test.exs[Code 2]
         {% else %}
-> <a id="test.exs" href="fixtures/test.exs">test.exs</a>
+> <a id="test.exs" href="fixtures/test.exs">Code 2: test.exs</a>
         {% endif %}
 `
                 + '\n'
@@ -78,7 +78,7 @@ anchor:test.exs[Code 2]
 > .link:fixtures/test.rs[Code 3: test.rs]
 anchor:test.rs[Code 3]
         {% else %}
-> <a id="test.rs" href="fixtures/test.rs">test.rs</a>
+> <a id="test.rs" href="fixtures/test.rs">Code 3: test.rs</a>
         {% endif %}
 `
                 + '\n'
@@ -100,7 +100,7 @@ anchor:test.rs[Code 3]
 > .link:fixtures/line.js[Code 4: line.js]
 anchor:line.js[Code 4]
         {% else %}
-> <a id="line.js" href="fixtures/line.js">line.js</a>
+> <a id="line.js" href="fixtures/line.js">Code 4: line.js</a>
         {% endif %}
 `
                 + '\n'
@@ -124,7 +124,7 @@ anchor:line.js[Code 4]
 > .link:fixtures/line.js[Code 5: line.js]
 anchor:line.js[Code 5]
         {% else %}
-> <a id="line.js" href="fixtures/line.js">line.js</a>
+> <a id="line.js" href="fixtures/line.js">Code 5: line.js</a>
         {% endif %}
 `
                 + '\n'
@@ -147,7 +147,7 @@ anchor:line.js[Code 5]
 > .link:fixtures/line.js[Code 6: line.js]
 anchor:line.js[Code 6]
         {% else %}
-> <a id="line.js" href="fixtures/line.js">line.js</a>
+> <a id="line.js" href="fixtures/line.js">Code 6: line.js</a>
         {% endif %}
 `
                 + '\n'
@@ -175,7 +175,7 @@ anchor:line.js[Code 6]
 > .link:fixtures/marker.cpp[Code 7: marker.cpp]
 anchor:marker.cpp[Code 7]
         {% else %}
-> <a id="marker.cpp" href="fixtures/marker.cpp">marker.cpp</a>
+> <a id="marker.cpp" href="fixtures/marker.cpp">Code 7: marker.cpp</a>
         {% endif %}
 `
                 + '\n'
@@ -241,7 +241,7 @@ anchor:marker.cpp[Code 7]
 > .link:fixtures/test.js[Code 8: This is a title]
 anchor:This is a title[Code 8]
         {% else %}
-> <a id="This is a title" href="fixtures/test.js">This is a title</a>
+> <a id="This is a title" href="fixtures/test.js">Code 8: This is a title</a>
         {% endif %}
 
 \`\`\` javascript

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -11,7 +11,7 @@ describe("parse", function () {
             var results = parse(content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include,title:\"test.js\"](fixtures/test.js)");
+            assert.equal(result.target, '[include,title:"test.js"](fixtures/test.js)');
 //------------------------------------------------------------------------------
             var expected =`\
         {% if file.type=="asciidoc" %}
@@ -22,7 +22,7 @@ anchor:test.js[Code 0]
         {% endif %}
 `
                 + '\n'
-                + '``` javascript\nconsole.log(\"test\");\n```';
+                + '``` javascript\nconsole.log("test");\n```';
 //------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
@@ -31,7 +31,7 @@ anchor:test.js[Code 0]
             var results = parse(exs_content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include, title:\"test.ts\", lang-typescript](fixtures/test.ts)");
+            assert.equal(result.target, '[include, title:"test.ts", lang-typescript](fixtures/test.ts)');
 //------------------------------------------------------------------------------
             var expected =`\
         {% if file.type=="asciidoc" %}
@@ -42,7 +42,7 @@ anchor:test.ts[Code 1]
         {% endif %}
 `
                 + '\n'
-                + '``` typescript\nconsole.log(\"test\");\n```';
+                + '``` typescript\nconsole.log("test");\n```';
 //------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
@@ -51,7 +51,7 @@ anchor:test.ts[Code 1]
             var results = parse(exs_content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include, title:\"test.exs\"](fixtures/test.exs)");
+            assert.equal(result.target, '[include, title:"test.exs"](fixtures/test.exs)');
 //------------------------------------------------------------------------------
             var expected =`\
         {% if file.type=="asciidoc" %}
@@ -62,7 +62,7 @@ anchor:test.exs[Code 2]
         {% endif %}
 `
                 + '\n'
-                + '``` elixir\nIO.puts \"test\"\n```';
+                + '``` elixir\nIO.puts "test"\n```';
 //------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
@@ -71,7 +71,7 @@ anchor:test.exs[Code 2]
             var results = parse(exs_content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include, title:\"test.rs\"](fixtures/test.rs)");
+            assert.equal(result.target, '[include, title:"test.rs"](fixtures/test.rs)');
 //------------------------------------------------------------------------------
             var expected =`\
         {% if file.type=="asciidoc" %}
@@ -89,7 +89,7 @@ anchor:test.rs[Code 3]
     });
     context("sliced text", function () {
         it("should return sliced object for replace", function () {
-            var multiLineContent = "[include:4-6, title:\"line.js\"](fixtures/line.js)";
+            var multiLineContent = '[include:4-6, title:"line.js"](fixtures/line.js)';
             var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
@@ -105,15 +105,15 @@ anchor:line.js[Code 4]
 `
                 + '\n'
                 + '``` javascript\n'
-                + 'console.log(\"this is line 4\");\n'
-                + 'console.log(\"this is line 5\");\n'
-                + 'console.log(\"this is line 6\");\n'
+                + 'console.log("this is line 4");\n'
+                + 'console.log("this is line 5");\n'
+                + 'console.log("this is line 6");\n'
                 + '```';
 //------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
         it("should return sliced `start`- text", function () {
-            var multiLineContent = "[include:9-, title:\"line.js\", line.js](fixtures/line.js)";
+            var multiLineContent = '[include:9-, title:"line.js", line.js](fixtures/line.js)';
             var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
@@ -129,14 +129,14 @@ anchor:line.js[Code 5]
 `
                 + '\n'
                 + '``` javascript\n'
-                + 'console.log(\"this is line 9\");\n'
-                + 'console.log(\"this is line 10\");\n'
+                + 'console.log("this is line 9");\n'
+                + 'console.log("this is line 10");\n'
                 + '```';
 //------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
         });
         it("should return sliced -`end` text", function () {
-            var multiLineContent = "[include:-2, title:\"line.js\", line.js](fixtures/line.js)";
+            var multiLineContent = '[include:-2, title:"line.js", line.js](fixtures/line.js)';
             var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
@@ -152,8 +152,8 @@ anchor:line.js[Code 6]
 `
                 + '\n'
                 + '``` javascript\n'
-                + 'console.log(\"this is line 1\");\n'
-                + 'console.log(\"this is line 2\");\n'
+                + 'console.log("this is line 1");\n'
+                + 'console.log("this is line 2");\n'
                 + '```';
 //------------------------------------------------------------------------------
             assert.equal(result.replaced, expected);
@@ -161,7 +161,7 @@ anchor:line.js[Code 6]
     });
     context("marker text", function () {
         it("should return sliced object for replace", function () {
-            const multiLineContent = "[include:\"marker0\", title:\"marker.cpp\", marker.cpp](fixtures/marker.cpp)";
+            const multiLineContent = '[include:"marker0", title:"marker.cpp", marker.cpp](fixtures/marker.cpp)';
             const expectedMarker01 = `    int a;
     int b;
     int c;`;

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -3,7 +3,7 @@
 import assert from "power-assert"
 import {parse, containIncludeCommand, splitLabelToCommands} from "../src/parser"
 var content = `
-[include](fixtures/test.js)
+[include,title](fixtures/test.js)
 `;
 describe("parse", function () {
     context("translate lang", function () {
@@ -11,40 +11,40 @@ describe("parse", function () {
             var results = parse(content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include](fixtures/test.js)");
+            assert.equal(result.target, "[include,title](fixtures/test.js)");
             var expected = '> <a name="test.js" href="fixtures/test.js">test.js</a>\n'
                 + '\n'
                 + '``` javascript\nconsole.log(\"test\");\n```';
             assert.equal(result.replaced, expected);
         });
         it("should prefer use lang-<aceMode>", function () {
-            var exs_content = `[include, lang-typescript](fixtures/test.ts)`;
+            var exs_content = `[include, title, lang-typescript](fixtures/test.ts)`;
             var results = parse(exs_content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include, lang-typescript](fixtures/test.ts)");
+            assert.equal(result.target, "[include, title, lang-typescript](fixtures/test.ts)");
             var expected = '> <a name="test.ts" href="fixtures/test.ts">test.ts</a>\n'
                 + '\n'
                 + '``` typescript\nconsole.log(\"test\");\n```';
             assert.equal(result.replaced, expected);
         });
         it("should translate elixir extensions", function () {
-            var exs_content = `[include](fixtures/test.exs)`;
+            var exs_content = `[include, title](fixtures/test.exs)`;
             var results = parse(exs_content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include](fixtures/test.exs)");
+            assert.equal(result.target, "[include, title](fixtures/test.exs)");
             var expected = '> <a name="test.exs" href="fixtures/test.exs">test.exs</a>\n'
                 + '\n'
                 + '``` elixir\nIO.puts \"test\"\n```';
             assert.equal(result.replaced, expected);
         });
         it("should translate Rust extensions", function () {
-            var exs_content = `[include](fixtures/test.rs)`;
+            var exs_content = `[include, title](fixtures/test.rs)`;
             var results = parse(exs_content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include](fixtures/test.rs)");
+            assert.equal(result.target, "[include, title](fixtures/test.rs)");
             var expected = '> <a name="test.rs" href="fixtures/test.rs">test.rs</a>\n'
                 + '\n'
                 + '``` rust\nextern crate num;\n```';
@@ -53,7 +53,7 @@ describe("parse", function () {
     });
     context("sliced text", function () {
         it("should return sliced object for replace", function () {
-            var multiLineContent = "[include:4-6, line.js](fixtures/line.js)";
+            var multiLineContent = "[include:4-6, title, line.js](fixtures/line.js)";
             var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
@@ -68,7 +68,7 @@ describe("parse", function () {
             assert.equal(result.replaced, expected);
         });
         it("should return sliced `start`- text", function () {
-            var multiLineContent = "[include:9-, line.js](fixtures/line.js)";
+            var multiLineContent = "[include:9-, title, line.js](fixtures/line.js)";
             var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
@@ -82,7 +82,7 @@ describe("parse", function () {
             assert.equal(result.replaced, expected);
         });
         it("should return sliced -`end` text", function () {
-            var multiLineContent = "[include:-2, line.js](fixtures/line.js)";
+            var multiLineContent = "[include:-2, title, line.js](fixtures/line.js)";
             var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
@@ -98,7 +98,7 @@ describe("parse", function () {
     });
     context("marker text", function () {
         it("should return sliced object for replace", function () {
-            const multiLineContent = "[include:marker0, marker.cpp](fixtures/marker.cpp)";
+            const multiLineContent = "[include:marker0, title, marker.cpp](fixtures/marker.cpp)";
             const expectedMarker01 = `    int a;
     int b;
     int c;`;
@@ -147,4 +147,36 @@ describe("parse", function () {
             assert(containIncludeCommand(commands));
         });
     })
+    context("title", function () {
+        it("should replace content without any title", function () {
+            var results = parse(`[include](fixtures/test.js)`, __dirname);
+            assert(results.length > 0);
+            var result = results[0];
+            assert.equal(result.target, "[include](fixtures/test.js)");
+            var expected = '\n'
+                + '\n'
+                + '``` javascript\nconsole.log(\"test\");\n```';
+            assert.equal(result.replaced, expected);
+        });
+        it("should replace content without any title", function () {
+            var results = parse(`[include, title](fixtures/test.js)`, __dirname);
+            assert(results.length > 0);
+            var result = results[0];
+            assert.equal(result.target, "[include, title](fixtures/test.js)");
+            var expected = '> <a name="test.js" href="fixtures/test.js">test.js</a>\n'
+                + '\n'
+                + '``` javascript\nconsole.log(\"test\");\n```';
+            assert.equal(result.replaced, expected);
+        });
+        it("should replace content without any title", function () {
+            var results = parse(`[include, title:'This is a title'](fixtures/test.js)`, __dirname);
+            assert(results.length > 0);
+            var result = results[0];
+            assert.equal(result.target, "[include, title:'This is a title'](fixtures/test.js)");
+            var expected = '> <a name="test.js" href="fixtures/test.js">This is a title</a>\n'
+                + '\n'
+                + '``` javascript\nconsole.log(\"test\");\n```';
+            assert.equal(result.replaced, expected);
+        });
+    });
 });

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -1,9 +1,9 @@
 // LICENSE : MIT
 "use strict";
 import assert from "power-assert"
-import {parse, containIncludeCommand, splitLabelToCommands} from "../src/parser"
+import {parse, parseVariablesFromLabel, containIncludeCommand, splitLabelToCommands} from "../src/parser"
 var content = `
-[include,title](fixtures/test.js)
+[include,title:"test.js"](fixtures/test.js)
 `;
 describe("parse", function () {
     context("translate lang", function () {
@@ -11,41 +11,41 @@ describe("parse", function () {
             var results = parse(content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include,title](fixtures/test.js)");
-            var expected = '> <a name="test.js" href="fixtures/test.js">test.js</a>\n'
+            assert.equal(result.target, "[include,title:\"test.js\"](fixtures/test.js)");
+            var expected = '> <a id="test.js" href="fixtures/test.js">test.js</a>\n'
                 + '\n'
                 + '``` javascript\nconsole.log(\"test\");\n```';
             assert.equal(result.replaced, expected);
         });
         it("should prefer use lang-<aceMode>", function () {
-            var exs_content = `[include, title, lang-typescript](fixtures/test.ts)`;
+            var exs_content = `[include, title:"test.ts", lang-typescript](fixtures/test.ts)`;
             var results = parse(exs_content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include, title, lang-typescript](fixtures/test.ts)");
-            var expected = '> <a name="test.ts" href="fixtures/test.ts">test.ts</a>\n'
+            assert.equal(result.target, "[include, title:\"test.ts\", lang-typescript](fixtures/test.ts)");
+            var expected = '> <a id="test.ts" href="fixtures/test.ts">test.ts</a>\n'
                 + '\n'
                 + '``` typescript\nconsole.log(\"test\");\n```';
             assert.equal(result.replaced, expected);
         });
         it("should translate elixir extensions", function () {
-            var exs_content = `[include, title](fixtures/test.exs)`;
+            var exs_content = `[include, title:"test.exs"](fixtures/test.exs)`;
             var results = parse(exs_content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include, title](fixtures/test.exs)");
-            var expected = '> <a name="test.exs" href="fixtures/test.exs">test.exs</a>\n'
+            assert.equal(result.target, "[include, title:\"test.exs\"](fixtures/test.exs)");
+            var expected = '> <a id="test.exs" href="fixtures/test.exs">test.exs</a>\n'
                 + '\n'
                 + '``` elixir\nIO.puts \"test\"\n```';
             assert.equal(result.replaced, expected);
         });
         it("should translate Rust extensions", function () {
-            var exs_content = `[include, title](fixtures/test.rs)`;
+            var exs_content = `[include, title:"test.rs"](fixtures/test.rs)`;
             var results = parse(exs_content, __dirname);
             assert(results.length > 0);
             var result = results[0];
-            assert.equal(result.target, "[include, title](fixtures/test.rs)");
-            var expected = '> <a name="test.rs" href="fixtures/test.rs">test.rs</a>\n'
+            assert.equal(result.target, "[include, title:\"test.rs\"](fixtures/test.rs)");
+            var expected = '> <a id="test.rs" href="fixtures/test.rs">test.rs</a>\n'
                 + '\n'
                 + '``` rust\nextern crate num;\n```';
             assert.equal(result.replaced, expected);
@@ -53,12 +53,12 @@ describe("parse", function () {
     });
     context("sliced text", function () {
         it("should return sliced object for replace", function () {
-            var multiLineContent = "[include:4-6, title, line.js](fixtures/line.js)";
+            var multiLineContent = "[include:4-6, title:\"line.js\"](fixtures/line.js)";
             var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, multiLineContent);
-            var expected = '> <a name="line.js" href="fixtures/line.js">line.js</a>\n'
+            var expected = '> <a id="line.js" href="fixtures/line.js">line.js</a>\n'
                 + '\n'
                 + '``` javascript\n'
                 + 'console.log(\"this is line 4\");\n'
@@ -68,12 +68,12 @@ describe("parse", function () {
             assert.equal(result.replaced, expected);
         });
         it("should return sliced `start`- text", function () {
-            var multiLineContent = "[include:9-, title, line.js](fixtures/line.js)";
+            var multiLineContent = "[include:9-, title:\"line.js\", line.js](fixtures/line.js)";
             var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, multiLineContent);
-            var expected = '> <a name="line.js" href="fixtures/line.js">line.js</a>\n'
+            var expected = '> <a id="line.js" href="fixtures/line.js">line.js</a>\n'
                 + '\n'
                 + '``` javascript\n'
                 + 'console.log(\"this is line 9\");\n'
@@ -82,12 +82,12 @@ describe("parse", function () {
             assert.equal(result.replaced, expected);
         });
         it("should return sliced -`end` text", function () {
-            var multiLineContent = "[include:-2, title, line.js](fixtures/line.js)";
+            var multiLineContent = "[include:-2, title:\"line.js\", line.js](fixtures/line.js)";
             var results = parse(multiLineContent, __dirname);
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, multiLineContent);
-            var expected = '> <a name="line.js" href="fixtures/line.js">line.js</a>\n'
+            var expected = '> <a id="line.js" href="fixtures/line.js">line.js</a>\n'
                 + '\n'
                 + '``` javascript\n'
                 + 'console.log(\"this is line 1\");\n'
@@ -98,7 +98,7 @@ describe("parse", function () {
     });
     context("marker text", function () {
         it("should return sliced object for replace", function () {
-            const multiLineContent = "[include:marker0, title, marker.cpp](fixtures/marker.cpp)";
+            const multiLineContent = "[include:\"marker0\", title:\"marker.cpp\", marker.cpp](fixtures/marker.cpp)";
             const expectedMarker01 = `    int a;
     int b;
     int c;`;
@@ -106,7 +106,7 @@ describe("parse", function () {
             assert(results.length > 0);
             const result = results[0];
             assert.equal(result.target, multiLineContent);
-            const expected = '> <a name="marker.cpp" href="fixtures/marker.cpp">marker.cpp</a>\n'
+            const expected = '> <a id="marker.cpp" href="fixtures/marker.cpp">marker.cpp</a>\n'
                 + '\n'
                 + '``` c_cpp\n'
                 + expectedMarker01 + "\n"
@@ -155,28 +155,44 @@ describe("parse", function () {
             assert.equal(result.target, "[include](fixtures/test.js)");
             var expected = '\n'
                 + '\n'
-                + '``` javascript\nconsole.log(\"test\");\n```';
+                + '``` javascript\nconsole.log("test");\n```';
             assert.equal(result.replaced, expected);
         });
-        it("should replace content without any title", function () {
-            var results = parse(`[include, title](fixtures/test.js)`, __dirname);
-            assert(results.length > 0);
-            var result = results[0];
-            assert.equal(result.target, "[include, title](fixtures/test.js)");
-            var expected = '> <a name="test.js" href="fixtures/test.js">test.js</a>\n'
-                + '\n'
-                + '``` javascript\nconsole.log(\"test\");\n```';
-            assert.equal(result.replaced, expected);
-        });
-        it("should replace content without any title", function () {
+        it("should replace content with a title", function () {
             var results = parse(`[include, title:'This is a title'](fixtures/test.js)`, __dirname);
             assert(results.length > 0);
             var result = results[0];
             assert.equal(result.target, "[include, title:'This is a title'](fixtures/test.js)");
-            var expected = '> <a name="test.js" href="fixtures/test.js">This is a title</a>\n'
+            var expected = '> <a id="This is a title" href="fixtures/test.js">This is a title</a>\n'
                 + '\n'
-                + '``` javascript\nconsole.log(\"test\");\n```';
+                + '``` javascript\nconsole.log("test");\n```';
             assert.equal(result.replaced, expected);
+        });
+    });
+    context("parseVariablesFromLabel ", function () {
+        it("should retrieve each attribute", function () {
+            const results = parseVariablesFromLabel(`include:"marker",title:"a test",id:"code1"`);
+            assert.equal(results.title, "a test");
+            assert.equal(results.id, "code1");
+            assert.equal(results.marker, "marker");
+        });
+        it("should retrieve title,id", function () {
+            const results = parseVariablesFromLabel(`include,title:"a test",id:"code1"`);
+            assert.equal(results.title, "a test");
+            assert.equal(results.id, "code1");
+            assert.equal(results.marker, undefined);
+        });
+        it("should retrieve title,id from full command", function () {
+            const results = parseVariablesFromLabel(`[include,title:"a test",id:"code1"](/path/to/file.ext)`);
+            assert.equal(results.title, "a test");
+            assert.equal(results.id, "code1");
+            assert.equal(results.marker, undefined);
+        });
+        it("should retrieve nothing", function () {
+            const results = parseVariablesFromLabel(`[import](/path/to/file.ext)`);
+            assert.equal(results.title, undefined);
+            assert.equal(results.id, undefined);
+            assert.equal(results.marker, undefined);
         });
     });
 });

--- a/test/title-test.js
+++ b/test/title-test.js
@@ -1,7 +1,6 @@
 // LICENSE : MIT
 "use strict";
 const assert = require("power-assert");
-//import {getTitle,hasTitle,hasTitleCustom} from "../src/title";
 import {getTitle} from "../src/title";
 
 describe("title", function () {

--- a/test/title-test.js
+++ b/test/title-test.js
@@ -1,0 +1,45 @@
+// LICENSE : MIT
+"use strict";
+const assert = require("power-assert");
+//import {getTitle,hasTitle,hasTitleCustom} from "../src/title";
+import {parseTitle} from "../src/title";
+
+describe("title", function () {
+
+    describe("title-label", function () {
+        describe("#getTitle", function () {
+            context("no title defined", function () {
+                it("should return false, empty", function () {
+                    const [exist,title] = parseTitle("test", "toto.js");
+                    assert.equal(exist, false);
+                    assert.equal(title, undefined);
+                });
+                it("should return true, empty", function () {
+                    const [exist,title] = parseTitle("title", "toto.js");
+                    assert.equal(exist, true);
+                    assert.equal(title, "toto.js");
+                });
+                it("should return true, the title contain title word", function () {
+                    const [exist,title] = parseTitle("title:'an example of title'", "toto.js");
+                    assert.equal(exist, true);
+                    assert.equal(title, "an example of title");
+                });
+                it("should return true, the title, contain import word", function () {
+                    const [exist,title] = parseTitle("title:'an example of import'", "toto.js");
+                    assert.equal(exist, true);
+                    assert.equal(title, "an example of import");
+                });
+                it("should return true, the title with punctuation", function () {
+                    const [exist,title] = parseTitle("title:'punctuation ?;:!'", "toto.js");
+                    assert.equal(exist, true);
+                    assert.equal(title, "punctuation ?;:!");
+                });
+                it("should return true, empty", function () {
+                    const [exist,title] = parseTitle("title, lang-typescript", "toto.js");
+                    assert.equal(exist, true);
+                    assert.equal(title, "toto.js");
+                });
+            });
+        });
+    });
+});

--- a/test/title-test.js
+++ b/test/title-test.js
@@ -2,44 +2,18 @@
 "use strict";
 const assert = require("power-assert");
 //import {getTitle,hasTitle,hasTitleCustom} from "../src/title";
-import {parseTitle} from "../src/title";
+import {getTitle} from "../src/title";
 
 describe("title", function () {
-
-    describe("title-label", function () {
-        describe("#getTitle", function () {
-            context("no title defined", function () {
-                it("should return false, empty", function () {
-                    const [exist,title] = parseTitle("test", "toto.js");
-                    assert.equal(exist, false);
-                    assert.equal(title, undefined);
-                });
-                it("should return true, empty", function () {
-                    const [exist,title] = parseTitle("title", "toto.js");
-                    assert.equal(exist, true);
-                    assert.equal(title, "toto.js");
-                });
-                it("should return true, the title contain title word", function () {
-                    const [exist,title] = parseTitle("title:'an example of title'", "toto.js");
-                    assert.equal(exist, true);
-                    assert.equal(title, "an example of title");
-                });
-                it("should return true, the title, contain import word", function () {
-                    const [exist,title] = parseTitle("title:'an example of import'", "toto.js");
-                    assert.equal(exist, true);
-                    assert.equal(title, "an example of import");
-                });
-                it("should return true, the title with punctuation", function () {
-                    const [exist,title] = parseTitle("title:'punctuation ?;:!'", "toto.js");
-                    assert.equal(exist, true);
-                    assert.equal(title, "punctuation ?;:!");
-                });
-                it("should return true, empty", function () {
-                    const [exist,title] = parseTitle("title, lang-typescript", "toto.js");
-                    assert.equal(exist, true);
-                    assert.equal(title, "toto.js");
-                });
-            });
+    context("#getTitle", function () {
+        it("should return the title", function () {
+            const obj={
+                   title:"an example of title",
+                   id:"test",
+                   marker:undefined
+            };
+            const title = getTitle(obj);
+            assert.equal(title, "an example of title");
         });
     });
 });


### PR DESCRIPTION
Pull-request proposal for feature #19 
- Now the title is optional
- Pass the option `title` to display the file name
- Pass a value to this previous option `title:"An example of custom title"` to
  display a custom title.

Bug/Known issue:
- Does not work properly if user write asciidoc pages. See issue #18.
  A workaround for now is to not pass any title, and create it directly in asciidoc.
  For example

``` adoc
.This is the title
[import](path/to/code.ext)
```

Possible improvment:
- Add code caption numbering. (would be useful for pdf format for
  example).
