### PR TITLE
fix(plugin): add fallback for Hardcode class

### DIFF
--- a/src/language-detection.js
+++ b/src/language-detection.js
@@ -19,6 +19,10 @@ export function lookupLanguageByAceMode(commands) {
                 resultAceMode = aceMode;
             }
         });
+        // not found the `matchLang` in AceMode
+        if (resultAceMode === undefined) {
+            resultAceMode = matchLang;
+        }
     });
     return resultAceMode;
 }

--- a/test/patterns/import-hardcode-not-found/actual.md
+++ b/test/patterns/import-hardcode-not-found/actual.md
@@ -1,0 +1,1 @@
+[import, lang-unknownLang](test.unknownLang)

--- a/test/patterns/import-hardcode-not-found/expected.md
+++ b/test/patterns/import-hardcode-not-found/expected.md
@@ -1,0 +1,9 @@
+{% if file.type=="asciidoc" %}
+> [[test.unknownLang]]link:test.unknownLang[test.unknownLang]
+{% else %}
+> <a id="test.unknownLang" href="test.unknownLang">test.unknownLang</a>
+{% endif %}
+
+``` unknownLang
+console.log("test");
+```

--- a/test/patterns/import-hardcode-not-found/test.unknownLang
+++ b/test/patterns/import-hardcode-not-found/test.unknownLang
@@ -1,0 +1,1 @@
+console.log("test");


### PR DESCRIPTION
 `[import, lang-vb](hello-world.vb)`.

The result will be

``````
```vb
content
```
``````

close  #26
