### PR TITLE
Add unindent behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ module.exports = {
 
 See [template/](template/) and [example/](example/) for details.
 
+You can also unindent the included text by specifying the `unindent` option:
+
+```js
+"pluginsConfig": {
+    "include-codeblock": {
+        "unindent": true
+    }
+}
+```
+
+Alternatively, unindent can be specified on a per-tag basis (see below)
+
 ## Usage
 
 **fixtures/test.js**
@@ -111,7 +123,7 @@ If you want to specify language type, put `lang-<lang-name>` to label.
 - :information_source: choose `<lang-name>` of `lang-<lang-name>` from language-map's `aceMode` value.
     - [blakeembrey/language-map: JSON version of the programming language map used in Linguist](https://github.com/blakeembrey/language-map "blakeembrey/language-map: JSON version of the programming language map used in Linguist")
 
-e.g.) typescript's aceMode value is `typescript`. 
+e.g.) typescript's aceMode value is `typescript`.
 
 - https://github.com/blakeembrey/language-map/blob/b72edb8c2cb1b05d098782aa85dd2f573ed96ba3/languages.json#L4140
 
@@ -148,7 +160,7 @@ You can also import snippet code similarly to [doxygen](https://www.stack.nl/~di
 For example, considering the following C++ source code
 
 - :information_source: should use **triple** comment mark for **markername**.
-    - `///`, `//!` or `###` etc.. 
+    - `///`, `//!` or `###` etc..
 
 ```cpp
 // test.cpp source code
@@ -164,7 +176,7 @@ int main()
 }
 ```
 
-In GitBook, the following commands 
+In GitBook, the following commands
 
 ```markdown
 [import:marker1](path/to/test.cpp)
@@ -183,6 +195,36 @@ The command `[import:marker0](path/to/test.cpp)` will result to
     int b;
     int c;
 ```
+
+### Unindented code
+
+Consider the following source code:
+
+```java
+class Hello {
+    /// [some-marker]
+    void world() {
+        // nice
+    }
+    /// [some-marker]
+}
+```
+
+And the following command:
+
+```
+[import:"some-marker",unindent:"true"](path/to/test.java)
+```
+
+This will result in unindented code:
+
+```java
+void world() {
+    // nice
+}
+```
+
+Unindent behaviour can also be specified globally in the plugin configuration.
 
 ## Example
 
@@ -223,11 +265,11 @@ Version 1.x template.
     > <a id="{{fileName}}" href="{{originalPath}}">{{fileName}}</a>
     {% endif %}
     {{/if}}
-    
+
     ``` {{lang}}
     {{{content}}}
     ```
-    
+
 Version 2.x template.
 
     ``` {{lang}}

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -1,7 +1,7 @@
 // LICENSE : MIT
 "use strict";
 import assert from "power-assert"
-import {parse, parseVariablesFromLabel, containIncludeCommand, splitLabelToCommands} from "../src/parser"
+import {parse, parseVariablesFromLabel, containIncludeCommand, splitLabelToCommands, strip} from "../src/parser"
 var content = `
 [include,title:"test.js"](fixtures/test.js)
 `;
@@ -65,4 +65,23 @@ describe("parse", function () {
             assert.equal(results.marker, undefined);
         });
     });
+    // inspired from https://github.com/rails/rails/blob/master/activesupport/test/core_ext/string_ext_test.rb
+    describe("strip", function () {
+        it("strips leading space from empty string", function () {
+            const stripped = strip("");
+            assert.equal(stripped, "");
+        });
+        it("strips leading space from one-liner", function () {
+            const stripped = strip("    x");
+            assert.equal(stripped, "x");
+        });
+        it("strips leading space from multi-liner with no margin", function () {
+            const stripped = strip("foo\n  bar\nbaz\n");
+            assert.equal(stripped, "foo\n  bar\nbaz\n");
+        });
+        it("strips leading space from multi-liner", function () {
+            const stripped = strip("      foo\n        bar\n      baz\n");
+            assert.equal(stripped, "foo\n  bar\nbaz\n");
+        });
+    })
 });


### PR DESCRIPTION
I'd like to include code snippets from my unit tests, because I know that code is working.

Currently, this usually leads to a lot of leading spaces that don't look pretty in the generated gitbook page.

This PR adds an `unindent` option that will unindent the code as much as possible while preserving indentation.

Would you consider adding this to this awesome plugin?

Cheers,
Aslak
