### PR TITLE
Plugins Config uses "true" instead of true

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Just add the desired optin under `pluginConfig` in the `book.json` file
     "pluginsConfig": {
         "include-codeblock": {
             "template": "ace",
-            "unindent": "true",
+            "unindent": true,
             "theme": "monokai"
         }
     }


### PR DESCRIPTION
Error when copypasta the example for `pluginsConfig`

`ConfigurationError: Error with book's configuration: pluginsConfig.include-codeblock.edit is not of a type(s) boolean`

This updates type to boolean for easier copypasta
![screen shot 2017-03-28 at 3 04 49 pm](https://cloud.githubusercontent.com/assets/6805534/24422636/2d31efc4-13c8-11e7-8f70-4a02a2fb5d6c.png)
