### PR TITLE
Make unindent work with sliced code

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -210,7 +210,7 @@ export function embedCode(kvMap, { filePath, originalPath, label }) {
     // Slice content via line numbers.
     if (hasSliceRange(label)) {
         const [start, end] = getSliceRange(label);
-        content = sliceCode(code, start, end);
+        content = sliceCode(code, start, end, unindent);
     } else if (hasMarker(kvm)) {
         // Slice content via markers.
         const marker = getMarker(kvm);

--- a/src/slicer.js
+++ b/src/slicer.js
@@ -46,9 +46,10 @@ export function hasSliceRange(label) {
  * @param {string} code
  * @param {number|undefined} [start]
  * @param {number|undefined} [end]
+ * @param {boolean|undefined} [untrimmed]
  * @returns {string}
  */
-export function sliceCode(code, start, end) {
+export function sliceCode(code, start, end, untrimmed) {
     if (start === undefined && end === undefined) {
         return code;
     }
@@ -59,5 +60,6 @@ export function sliceCode(code, start, end) {
     if (end === undefined) {
         end = slitted.length;
     }
-    return slitted.slice(start - 1, end).join("\n").trim();
+    const sliced = slitted.slice(start - 1, end).join("\n");
+    return untrimmed ? sliced : sliced.trim();
 }

--- a/test/patterns/import-unindent-slice/actual.md
+++ b/test/patterns/import-unindent-slice/actual.md
@@ -1,0 +1,1 @@
+[import:1-2](test.js)

--- a/test/patterns/import-unindent-slice/book.js
+++ b/test/patterns/import-unindent-slice/book.js
@@ -1,0 +1,7 @@
+module.exports = {
+    pluginsConfig: {
+        "include-codeblock": {
+            unindent: true
+        }
+    }
+};

--- a/test/patterns/import-unindent-slice/expected.md
+++ b/test/patterns/import-unindent-slice/expected.md
@@ -1,0 +1,4 @@
+``` javascript
+foo;
+bar;
+```

--- a/test/patterns/import-unindent-slice/test.js
+++ b/test/patterns/import-unindent-slice/test.js
@@ -1,0 +1,3 @@
+    foo;
+    bar;
+    baz;


### PR DESCRIPTION
The `unindent` option doesn't currently work with sliced code because [the slicer trims code](https://github.com/azu/gitbook-plugin-include-codeblock/blob/5278db9264a42722e79cf0580f2dbd38f4cd6d8f/src/slicer.js#L62) before unindenting happens.  So the first line of code always has 0 spaces and no unindenting happens.

I've added a test case that fails without changes to the source.  With these changes, sliced code can be properly unindented.